### PR TITLE
feat: add PostgreSQL support to SchemaUpdateCommand and MigrateCommand

### DIFF
--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -9,7 +9,6 @@ use MonkeysLegion\Cli\Console\Command;
 use MonkeysLegion\Cli\Console\Attributes\Command as CommandAttr;
 use PDO;
 use PDOException;
-use RuntimeException;
 
 #[CommandAttr('migrate', 'Run outstanding migrations')]
 final class MigrateCommand extends Command

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -9,6 +9,7 @@ use MonkeysLegion\Cli\Console\Command;
 use MonkeysLegion\Cli\Console\Attributes\Command as CommandAttr;
 use PDO;
 use PDOException;
+use RuntimeException;
 
 #[CommandAttr('migrate', 'Run outstanding migrations')]
 final class MigrateCommand extends Command
@@ -28,20 +29,14 @@ final class MigrateCommand extends Command
             /* -----------------------------------------------------------------
          | 1) Ensure the bookkeeping table exists
          * ----------------------------------------------------------------*/
-            $pdo->exec(
-                'CREATE TABLE IF NOT EXISTS ' . self::MIGRATIONS_TABLE . ' (
-                id          INT AUTO_INCREMENT PRIMARY KEY,
-                filename    VARCHAR(255) NOT NULL,
-                batch       INT NOT NULL,
-                executed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
-            );
+            $driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+            $pdo->exec($this->migrationsTableDdl($driver));
 
             /* -----------------------------------------------------------------
          | 2) Determine pending migrations
          * ----------------------------------------------------------------*/
             $table = self::MIGRATIONS_TABLE;
-            $applied = $this->safeQuery($pdo, "SELECT filename FROM `$table`")
+            $applied = $this->safeQuery($pdo, "SELECT filename FROM {$table}")
                 ->fetchAll(PDO::FETCH_COLUMN);
 
             $files   = \glob(\base_path('var/migrations/*.sql')) ?: [];
@@ -53,7 +48,7 @@ final class MigrateCommand extends Command
             }
 
             $batch = (int) (
-                $this->safeQuery($pdo, "SELECT MAX(batch) FROM `$table`")
+                $this->safeQuery($pdo, "SELECT MAX(batch) FROM {$table}")
                 ->fetchColumn() ?: 0
             ) + 1;
 
@@ -82,8 +77,10 @@ final class MigrateCommand extends Command
                         try {
                             $pdo->exec($stmt);
                         } catch (PDOException $e) {
-                            // Skip duplicate‐column or table‐exists errors
-                            if (in_array($e->getCode(), ['42S21', '42S01'], true)) {
+                            // Skip duplicate-column or table-exists errors
+                            // MySQL: 42S21 (dup column), 42S01 (dup table)
+                            // PostgreSQL: 42P07 (dup table), 42701 (dup column)
+                            if (in_array($e->getCode(), ['42S21', '42S01', '42P07', '42701'], true)) {
                                 $this->line('Skipped (already applied statement): ' . substr($stmt, 0, 50) . '…');
                                 continue;
                             }
@@ -118,5 +115,31 @@ final class MigrateCommand extends Command
             $this->error($e->getMessage());
             return self::FAILURE;
         }
+    }
+
+    /**
+     * Return the CREATE TABLE DDL for the migrations bookkeeping table,
+     * adapted to the current database driver.
+     */
+    private function migrationsTableDdl(string $driver): string
+    {
+        $table = self::MIGRATIONS_TABLE;
+
+        if ($driver === 'pgsql') {
+            return "CREATE TABLE IF NOT EXISTS {$table} (
+                id          SERIAL PRIMARY KEY,
+                filename    VARCHAR(255) NOT NULL,
+                batch       INT NOT NULL,
+                executed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )";
+        }
+
+        // MySQL (default)
+        return "CREATE TABLE IF NOT EXISTS {$table} (
+            id          INT AUTO_INCREMENT PRIMARY KEY,
+            filename    VARCHAR(255) NOT NULL,
+            batch       INT NOT NULL,
+            executed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
     }
 }

--- a/src/Command/SchemaUpdateCommand.php
+++ b/src/Command/SchemaUpdateCommand.php
@@ -173,12 +173,14 @@ final class SchemaUpdateCommand extends Command
      */
     private function introspectPgsql(\PDO $pdo): array
     {
-        $tablesStmt = $pdo->query(
-            "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+        // Resolve the active schema from search_path rather than hardcoding 'public'
+        $schemaStmt = $pdo->query('SELECT current_schema()');
+        $pgSchema   = $schemaStmt !== false ? ($schemaStmt->fetchColumn() ?: 'public') : 'public';
+
+        $tablesStmt = $pdo->prepare(
+            'SELECT tablename FROM pg_tables WHERE schemaname = :schema'
         );
-        if ($tablesStmt === false) {
-            throw new \RuntimeException('Failed to list PostgreSQL tables');
-        }
+        $tablesStmt->execute(['schema' => $pgSchema]);
         /** @var list<string> $tables */
         $tables = $tablesStmt->fetchAll(\PDO::FETCH_COLUMN);
 
@@ -189,7 +191,7 @@ final class SchemaUpdateCommand extends Command
                    column_default  AS "Default",
                    CASE WHEN column_default LIKE 'nextval%%' THEN 'auto_increment' ELSE '' END AS "Extra"
               FROM information_schema.columns
-             WHERE table_schema = 'public'
+             WHERE table_schema = :schema
                AND table_name  = :table
              ORDER BY ordinal_position
         SQL;
@@ -197,7 +199,7 @@ final class SchemaUpdateCommand extends Command
         $schema = [];
         foreach ($tables as $table) {
             $colsStmt = $pdo->prepare($colSql);
-            $colsStmt->execute(['table' => $table]);
+            $colsStmt->execute(['schema' => $pgSchema, 'table' => $table]);
             /** @var list<array<string, mixed>> $cols */
             $cols = $colsStmt->fetchAll(\PDO::FETCH_ASSOC);
 
@@ -261,20 +263,32 @@ final class SchemaUpdateCommand extends Command
      */
     private function createDatabasePgsql(string $dsn, string $appUser, string $appPass): bool
     {
+        // Parse all DSN options so we preserve sslmode, options, etc.
         $parts = [];
         foreach (explode(';', substr($dsn, 6)) as $chunk) {
             if ($chunk === '') continue;
             [$k, $v] = array_map('trim', explode('=', $chunk, 2));
             $parts[$k] = $v;
         }
-        $host = $parts['host'] ?? '127.0.0.1';
-        $port = $parts['port'] ?? 5432;
-        $db   = $parts['dbname'] ?? 'app';
+        $db = $parts['dbname'] ?? 'app';
+
+        // Validate identifier: only word chars, digits, hyphens, dots allowed
+        if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_\-\.]*$/', $db)) {
+            $this->error("Invalid database name: '{$db}'");
+            return false;
+        }
+
+        // Rebuild DSN swapping dbname to 'postgres' while keeping every other option
+        $parts['dbname'] = 'postgres';
+        $maintenanceDsn  = 'pgsql:' . implode(';', array_map(
+            static fn(string $k, string $v): string => "{$k}={$v}",
+            array_keys($parts),
+            array_values($parts)
+        ));
 
         try {
-            // Connect to the 'postgres' maintenance database
             $pdo = new \PDO(
-                sprintf('pgsql:host=%s;port=%s;dbname=postgres', $host, $port),
+                $maintenanceDsn,
                 $appUser,
                 $appPass,
                 [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]
@@ -285,8 +299,9 @@ final class SchemaUpdateCommand extends Command
             $stmt->execute(['db' => $db]);
 
             if (!$stmt->fetch()) {
-                // Identifier quoting – $db comes from config, not user input
-                $pdo->exec("CREATE DATABASE \"{$db}\" ENCODING 'UTF8'");
+                // Safe: $db validated above against strict identifier regex
+                $quoted = '"' . str_replace('"', '""', $db) . '"';
+                $pdo->exec("CREATE DATABASE {$quoted} ENCODING 'UTF8'");
             }
 
             $this->info("✔️  Database '{$db}' created successfully.");

--- a/src/Command/SchemaUpdateCommand.php
+++ b/src/Command/SchemaUpdateCommand.php
@@ -196,9 +196,10 @@ final class SchemaUpdateCommand extends Command
              ORDER BY ordinal_position
         SQL;
 
+        $colsStmt = $pdo->prepare($colSql);
+
         $schema = [];
         foreach ($tables as $table) {
-            $colsStmt = $pdo->prepare($colSql);
             $colsStmt->execute(['schema' => $pgSchema, 'table' => $table]);
             /** @var list<array<string, mixed>> $cols */
             $cols = $colsStmt->fetchAll(\PDO::FETCH_ASSOC);
@@ -298,13 +299,19 @@ final class SchemaUpdateCommand extends Command
             $stmt = $pdo->prepare("SELECT 1 FROM pg_database WHERE datname = :db");
             $stmt->execute(['db' => $db]);
 
+            $created = false;
             if (!$stmt->fetch()) {
                 // Safe: $db validated above against strict identifier regex
                 $quoted = '"' . str_replace('"', '""', $db) . '"';
                 $pdo->exec("CREATE DATABASE {$quoted} ENCODING 'UTF8'");
+                $created = true;
             }
 
-            $this->info("✔️  Database '{$db}' created successfully.");
+            if ($created) {
+                $this->info("✔️  Database '{$db}' created successfully.");
+            } else {
+                $this->info("ℹ️  Database '{$db}' already exists, skipping creation.");
+            }
             return true;
         } catch (\PDOException $e) {
             $this->error("Failed to create database: {$e->getMessage()}");

--- a/src/Command/SchemaUpdateCommand.php
+++ b/src/Command/SchemaUpdateCommand.php
@@ -86,8 +86,10 @@ final class SchemaUpdateCommand extends Command
                     try {
                         $pdo->exec($stmt);
                     } catch (\PDOException $e) {
-                        // ignore “already exists” / duplicate-column errors
-                        if (in_array($e->getCode(), ['42S21', '42S01'], true)) {
+                        // ignore "already exists" / duplicate-column errors
+                        // MySQL: 42S21 (dup column), 42S01 (dup table)
+                        // PostgreSQL: 42P07 (dup table), 42701 (dup column)
+                        if (in_array($e->getCode(), ['42S21', '42S01', '42P07', '42701'], true)) {
                             $this->line('Skipped: ' . substr($stmt, 0, 50) . '…');
                             continue;
                         }
@@ -112,15 +114,33 @@ final class SchemaUpdateCommand extends Command
     }
 
     /**
-     * Introspect the MySQL schema into an array:
+     * Introspect the database schema into an array:
      *  [ tableName => [ columnName => columnInfoArray, … ], … ]
+     *
+     * Returns the same structure for both MySQL and PostgreSQL so that
+     * MigrationGenerator::diff() can consume it identically.
      *
      * @return array<string, array<string, array<string, mixed>>>
      */
     private function introspectSchema(): array
     {
-        $pdo = $this->db->pdo();
+        $pdo    = $this->db->pdo();
+        $driver = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
 
+        if ($driver === 'pgsql') {
+            return $this->introspectPgsql($pdo);
+        }
+
+        return $this->introspectMysql($pdo);
+    }
+
+    /**
+     * MySQL introspection via SHOW TABLES / SHOW COLUMNS.
+     *
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    private function introspectMysql(\PDO $pdo): array
+    {
         $tablesStmt = $this->safeQuery($pdo, "SHOW TABLES");
         /** @var list<string> $tables */
         $tables = $tablesStmt->fetchAll(\PDO::FETCH_COLUMN);
@@ -128,6 +148,56 @@ final class SchemaUpdateCommand extends Command
         $schema = [];
         foreach ($tables as $table) {
             $colsStmt = $this->safeQuery($pdo, "SHOW COLUMNS FROM `{$table}`");
+            /** @var list<array<string, mixed>> $cols */
+            $cols = $colsStmt->fetchAll(\PDO::FETCH_ASSOC);
+
+            $schema[$table] = [];
+            foreach ($cols as $col) {
+                if (!isset($col['Field']) || !is_string($col['Field'])) {
+                    throw new \RuntimeException("Invalid column definition in table '{$table}'");
+                }
+                $schema[$table][$col['Field']] = $col;
+            }
+        }
+        return $schema;
+    }
+
+    /**
+     * PostgreSQL introspection via pg_tables / information_schema.columns.
+     *
+     * Column rows are aliased to the same keys that MySQL returns
+     * (Field, Type, Null, Default, Extra) so the diff layer receives a
+     * uniform structure.
+     *
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    private function introspectPgsql(\PDO $pdo): array
+    {
+        $tablesStmt = $pdo->query(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+        );
+        if ($tablesStmt === false) {
+            throw new \RuntimeException('Failed to list PostgreSQL tables');
+        }
+        /** @var list<string> $tables */
+        $tables = $tablesStmt->fetchAll(\PDO::FETCH_COLUMN);
+
+        $colSql = <<<'SQL'
+            SELECT column_name     AS "Field",
+                   data_type       AS "Type",
+                   is_nullable     AS "Null",
+                   column_default  AS "Default",
+                   CASE WHEN column_default LIKE 'nextval%%' THEN 'auto_increment' ELSE '' END AS "Extra"
+              FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND table_name  = :table
+             ORDER BY ordinal_position
+        SQL;
+
+        $schema = [];
+        foreach ($tables as $table) {
+            $colsStmt = $pdo->prepare($colSql);
+            $colsStmt->execute(['table' => $table]);
             /** @var list<array<string, mixed>> $cols */
             $cols = $colsStmt->fetchAll(\PDO::FETCH_ASSOC);
 
@@ -174,12 +244,64 @@ final class SchemaUpdateCommand extends Command
         $appUser = isset($conn['username']) && is_string($conn['username']) ? $conn['username'] : 'root';
         $appPass = isset($conn['password']) && is_string($conn['password']) ? $conn['password'] : '';
 
-        if (!str_starts_with($dsn, 'mysql:')) {
-            $this->error('Database creation skipped – driver not MySQL.');
-            return false;
+        if (str_starts_with($dsn, 'pgsql:')) {
+            return $this->createDatabasePgsql($dsn, $appUser, $appPass);
         }
 
-        // Parse DSN to get database name and connection details
+        if (str_starts_with($dsn, 'mysql:')) {
+            return $this->createDatabaseMysql($dsn, $appUser, $appPass);
+        }
+
+        $this->error('Database creation skipped – unsupported driver.');
+        return false;
+    }
+
+    /**
+     * Create a PostgreSQL database via the 'postgres' maintenance DB.
+     */
+    private function createDatabasePgsql(string $dsn, string $appUser, string $appPass): bool
+    {
+        $parts = [];
+        foreach (explode(';', substr($dsn, 6)) as $chunk) {
+            if ($chunk === '') continue;
+            [$k, $v] = array_map('trim', explode('=', $chunk, 2));
+            $parts[$k] = $v;
+        }
+        $host = $parts['host'] ?? '127.0.0.1';
+        $port = $parts['port'] ?? 5432;
+        $db   = $parts['dbname'] ?? 'app';
+
+        try {
+            // Connect to the 'postgres' maintenance database
+            $pdo = new \PDO(
+                sprintf('pgsql:host=%s;port=%s;dbname=postgres', $host, $port),
+                $appUser,
+                $appPass,
+                [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]
+            );
+
+            // Check if database already exists
+            $stmt = $pdo->prepare("SELECT 1 FROM pg_database WHERE datname = :db");
+            $stmt->execute(['db' => $db]);
+
+            if (!$stmt->fetch()) {
+                // Identifier quoting – $db comes from config, not user input
+                $pdo->exec("CREATE DATABASE \"{$db}\" ENCODING 'UTF8'");
+            }
+
+            $this->info("✔️  Database '{$db}' created successfully.");
+            return true;
+        } catch (\PDOException $e) {
+            $this->error("Failed to create database: {$e->getMessage()}");
+            return false;
+        }
+    }
+
+    /**
+     * Create a MySQL database (original logic preserved).
+     */
+    private function createDatabaseMysql(string $dsn, string $appUser, string $appPass): bool
+    {
         $parts = [];
         foreach (explode(';', substr($dsn, 6)) as $chunk) {
             if ($chunk === '') continue;
@@ -188,12 +310,11 @@ final class SchemaUpdateCommand extends Command
         }
         $host = $parts['host'] ?? '127.0.0.1';
         $port = $parts['port'] ?? 3306;
-        $db = $parts['dbname'] ?? 'app';
+        $db   = $parts['dbname'] ?? 'app';
 
         $dsnTpl = 'mysql:host=%s;port=%s;charset=utf8mb4';
 
         try {
-            // Connect without specifying database
             $pdo = new \PDO(
                 sprintf($dsnTpl, $host, $port),
                 $appUser,
@@ -204,7 +325,6 @@ final class SchemaUpdateCommand extends Command
                 ]
             );
 
-            // Create the database
             $pdo->exec(
                 sprintf(
                     'CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci',
@@ -216,7 +336,6 @@ final class SchemaUpdateCommand extends Command
             return true;
         } catch (\PDOException $e) {
             if ($host !== '127.0.0.1') {
-                // Retry with localhost
                 try {
                     $pdo = new \PDO(
                         sprintf($dsnTpl, '127.0.0.1', $port),


### PR DESCRIPTION
- introspectSchema() now detects driver and branches for pgsql vs mysql
- createDatabase() supports pgsql: DSN (connects to postgres maintenance DB)
- MigrateCommand uses SERIAL PRIMARY KEY for PostgreSQL DDL
- Removed MySQL-specific backtick quoting from MigrateCommand queries
- Expanded error codes to include PostgreSQL duplicate-object SQLSTATEs